### PR TITLE
add expand_tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   Applies the given function to each Unicode code point in the string, carrying along an accumulator, and returns the final accumulator value.  
   Unicode-aware: decodes the string into code points and applies the function to each.
 
+- add: `expand_tabs`  
+  Expands tab characters ('\t') in the string to spaces, depending on the current column and tab size.  
+  The column is reset to zero after each newline ('\n'). CJK characters are treated as width 2.  
+  Raises [Invalid_argument] if [tab_size] <= 0.
+
 ## [v0.2.0] - 2025-06-29
 
 - add: `trim`  

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ module Stringx : sig
   (** Compare two strings for equality, ignoring ASCII case.
       Example: equal_fold "Go" "go" = true *)
 
+  val expand_tabs : string -> int -> string
+  (** Expand tab characters ('\\t') in the string to spaces, depending on the current column and tab size.
+      The column is reset to zero after each newline ('\\n'). CJK characters are treated as width 2.
+      Raises [Invalid_argument] if [tab_size] <= 0.
+      Example: expand_tabs "a\\tbc\\tdef\\tghij\\tk" 4 = "a   bc  def ghij    k" *)
+
   val fields : string -> string list
   (** Split a string by runs of Unicode whitespace. Returns an empty list if only whitespace.
       Example: fields "  foo bar  baz   " = ["foo"; "bar"; "baz"] *)

--- a/lib/stringx.mli
+++ b/lib/stringx.mli
@@ -572,3 +572,15 @@ val iter : (Uchar.t -> unit) -> string -> unit
 val fold : ('acc -> Uchar.t -> 'acc) -> 'acc -> string -> 'acc
 (** [fold f init s] applies [f acc u] to each Unicode code point [u] of [s],
     carrying along an accumulator [acc], and returns the final accumulator. *)
+
+val expand_tabs : string -> int -> string
+(** [expand_tabs s tab_size] expands tab characters ('\t') in [s] to spaces,
+    depending on the current column and [tab_size]. The column is reset to zero
+    after each newline ('\n'). CJK characters are treated as width 2.
+
+    Raises [Invalid_argument] if [tab_size] <= 0.
+
+    Examples:
+    - expand_tabs "a\tbc\tdef\tghij\tk" 4 = "a bc def ghij k"
+    - expand_tabs "abcdefg\thij\nk\tl" 4 = "abcdefg hij\nk l"
+    - expand_tabs "z中\t文\tw" 4 = "z中 文 w" *)

--- a/test/test_stringx.ml
+++ b/test/test_stringx.ml
@@ -565,6 +565,19 @@ let test_fold_sum () =
   let sum acc u = acc + Uchar.to_int u in
   Alcotest.(check int) "sum code point ints" 198 (fold sum 0 "ABC")
 
+let test_expand_tabs () =
+  let open Stringx in
+  Alcotest.(check string)
+    "expand_tabs basic" "a   bc  def ghij    k"
+    (expand_tabs "a\tbc\tdef\tghij\tk" 4);
+  Alcotest.(check string)
+    "expand_tabs newline" "abcdefg hij\nk   l"
+    (expand_tabs "abcdefg\thij\nk\tl" 4);
+  Alcotest.(check string) "expand_tabs CJK" "z中 文  w" (expand_tabs "z中\t文\tw" 4);
+  Alcotest.check_raises "expand_tabs tab_size <= 0"
+    (Invalid_argument "expand_tabs: tab_size must be > 0") (fun () ->
+      ignore (expand_tabs "abc\tdef" 0))
+
 let () =
   run "stringx"
     [
@@ -623,4 +636,6 @@ let () =
       ( "fold count tests",
         [ test_case "fold count basic" `Quick test_fold_count ] );
       ("fold sum tests", [ test_case "fold sum basic" `Quick test_fold_sum ]);
+      ( "expand tabs tests",
+        [ test_case "expand tabs basic" `Quick test_expand_tabs ] );
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a function to expand tab characters in strings into spaces, correctly handling CJK characters as double-width and resetting column counts after newlines.
* **Documentation**
  * Updated documentation with usage examples and details for the new tab expansion feature.
* **Tests**
  * Introduced tests to verify correct tab expansion, including handling of CJK characters and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->