### PR TITLE
add first_rune_to_upper, first_rune_to_lower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   The column is reset to zero after each newline ('\n'). CJK characters are treated as width 2.  
   Raises [Invalid_argument] if [tab_size] <= 0.
 
+- add: `first_rune_to_lower`  
+  Converts the first Unicode code point to lower case if it is an uppercase ASCII letter.  
+  Unicode-aware: only the first code point is affected, the rest are unchanged.
+
 ## [v0.2.0] - 2025-06-29
 
 - add: `trim`  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   Converts the first Unicode code point to lower case if it is an uppercase ASCII letter.  
   Unicode-aware: only the first code point is affected, the rest are unchanged.
 
+- add: `first_rune_to_upper`  
+  Converts the first Unicode code point to upper case if it is a lowercase ASCII letter.  
+  Unicode-aware: only the first code point is affected, the rest are unchanged.
+
 ## [v0.2.0] - 2025-06-29
 
 - add: `trim`  

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ module Stringx : sig
       - first_rune_to_lower "こんにちは" = "こんにちは"
   *)
 
+  val first_rune_to_upper : string -> string
+  (** Convert the first Unicode code point to upper case if it is a lowercase ASCII letter.
+      Unicode-aware: only the first code point is affected, the rest are unchanged.
+      Examples:
+      - first_rune_to_upper "camelCase" = "CamelCase"
+      - first_rune_to_upper "CamelCase" = "CamelCase"
+      - first_rune_to_upper "camel" = "Camel"
+      - first_rune_to_upper "こんにちは" = "こんにちは"
+  *)
+
   val fields : string -> string list
   (** Split a string by runs of Unicode whitespace. Returns an empty list if only whitespace.
       Example: fields "  foo bar  baz   " = ["foo"; "bar"; "baz"] *)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ module Stringx : sig
       Raises [Invalid_argument] if [tab_size] <= 0.
       Example: expand_tabs "a\\tbc\\tdef\\tghij\\tk" 4 = "a   bc  def ghij    k" *)
 
+  val first_rune_to_lower : string -> string
+  (** Convert the first Unicode code point to lower case if it is an uppercase ASCII letter.
+      Unicode-aware: only the first code point is affected, the rest are unchanged.
+      Examples:
+      - first_rune_to_lower "CamelCase" = "camelCase"
+      - first_rune_to_lower "CAMEL" = "cAMEL"
+      - first_rune_to_lower "こんにちは" = "こんにちは"
+  *)
+
   val fields : string -> string list
   (** Split a string by runs of Unicode whitespace. Returns an empty list if only whitespace.
       Example: fields "  foo bar  baz   " = ["foo"; "bar"; "baz"] *)

--- a/lib/stringx.ml
+++ b/lib/stringx.ml
@@ -1007,3 +1007,24 @@ let expand_tabs (s : string) (tab_size : int) : string =
   in
   aux 0;
   Buffer.contents buf
+
+let first_rune_to_lower (s : string) : string =
+  let dec = Uutf.decoder ~encoding:`UTF_8 (`String s) in
+  let buf = Buffer.create (String.length s) in
+  let rec aux first =
+    match Uutf.decode dec with
+    | `Uchar u when first ->
+        let c = Uchar.to_int u in
+        let u' =
+          if c >= 0x41 && c <= 0x5A then Uchar.of_int (c + 0x20) else u
+        in
+        Buffer.add_utf_8_uchar buf u';
+        aux false
+    | `Uchar u ->
+        Buffer.add_utf_8_uchar buf u;
+        aux false
+    | `End | `Await -> ()
+    | `Malformed _ -> aux false
+  in
+  aux true;
+  Buffer.contents buf

--- a/lib/stringx.ml
+++ b/lib/stringx.ml
@@ -1047,3 +1047,33 @@ let first_rune_to_lower (s : string) : string =
   in
   aux true;
   Buffer.contents buf
+
+(** [first_rune_to_upper s] returns [s] with the first Unicode code point
+    converted to upper case if it is a lowercase ASCII letter. Unicode-aware:
+    only the first code point is affected, the rest are unchanged.
+
+    Examples:
+    - first_rune_to_upper "camelCase" = "CamelCase"
+    - first_rune_to_upper "CamelCase" = "CamelCase"
+    - first_rune_to_upper "camel" = "Camel"
+    - first_rune_to_upper "こんにちは" = "こんにちは" *)
+let first_rune_to_upper (s : string) : string =
+  let dec = Uutf.decoder ~encoding:`UTF_8 (`String s) in
+  let buf = Buffer.create (String.length s) in
+  let rec aux first =
+    match Uutf.decode dec with
+    | `Uchar u when first ->
+        let c = Uchar.to_int u in
+        let u' =
+          if c >= 0x61 && c <= 0x7A then Uchar.of_int (c - 0x20) else u
+        in
+        Buffer.add_utf_8_uchar buf u';
+        aux false
+    | `Uchar u ->
+        Buffer.add_utf_8_uchar buf u;
+        aux false
+    | `End | `Await -> ()
+    | `Malformed _ -> aux false
+  in
+  aux true;
+  Buffer.contents buf

--- a/lib/stringx.ml
+++ b/lib/stringx.ml
@@ -982,6 +982,16 @@ let rune_width (u : Uchar.t) : int =
   then 2
   else 1
 
+(** [expand_tabs s tab_size] expands tab characters ('\t') in [s] to spaces,
+    depending on the current column and [tab_size]. The column is reset to zero
+    after each newline ('\n'). CJK characters are treated as width 2.
+
+    Raises [Invalid_argument] if [tab_size] <= 0.
+
+    Examples:
+    - expand_tabs "a\tbc\tdef\tghij\tk" 4 = "a bc def ghij k"
+    - expand_tabs "abcdefg\thij\nk\tl" 4 = "abcdefg hij\nk l"
+    - expand_tabs "z中\t文\tw" 4 = "z中 文 w" *)
 let expand_tabs (s : string) (tab_size : int) : string =
   if tab_size <= 0 then invalid_arg "expand_tabs: tab_size must be > 0";
   let dec = Uutf.decoder ~encoding:`UTF_8 (`String s) in
@@ -1008,6 +1018,15 @@ let expand_tabs (s : string) (tab_size : int) : string =
   aux 0;
   Buffer.contents buf
 
+(** [first_rune_to_lower s] returns [s] with the first Unicode code point
+    converted to lower case if it is an uppercase ASCII letter. Unicode-aware:
+    only the first code point is affected, the rest are unchanged.
+
+    Examples:
+    - first_rune_to_lower "CamelCase" = "camelCase"
+    - first_rune_to_lower "camelCase" = "camelCase"
+    - first_rune_to_lower "CAMEL" = "cAMEL"
+    - first_rune_to_lower "こんにちは" = "こんにちは" *)
 let first_rune_to_lower (s : string) : string =
   let dec = Uutf.decoder ~encoding:`UTF_8 (`String s) in
   let buf = Buffer.create (String.length s) in

--- a/lib/stringx.mli
+++ b/lib/stringx.mli
@@ -584,3 +584,14 @@ val expand_tabs : string -> int -> string
     - expand_tabs "a\tbc\tdef\tghij\tk" 4 = "a bc def ghij k"
     - expand_tabs "abcdefg\thij\nk\tl" 4 = "abcdefg hij\nk l"
     - expand_tabs "z中\t文\tw" 4 = "z中 文 w" *)
+
+val first_rune_to_lower : string -> string
+(** [first_rune_to_lower s] returns [s] with the first Unicode code point
+    converted to lower case if it is an uppercase ASCII letter. Unicode-aware:
+    only the first code point is affected, the rest are unchanged.
+
+    Examples:
+    - first_rune_to_lower "CamelCase" = "camelCase"
+    - first_rune_to_lower "camelCase" = "camelCase"
+    - first_rune_to_lower "CAMEL" = "cAMEL"
+    - first_rune_to_lower "こんにちは" = "こんにちは" *)

--- a/lib/stringx.mli
+++ b/lib/stringx.mli
@@ -595,3 +595,14 @@ val first_rune_to_lower : string -> string
     - first_rune_to_lower "camelCase" = "camelCase"
     - first_rune_to_lower "CAMEL" = "cAMEL"
     - first_rune_to_lower "こんにちは" = "こんにちは" *)
+
+val first_rune_to_upper : string -> string
+(** [first_rune_to_upper s] returns [s] with the first Unicode code point
+    converted to upper case if it is a lowercase ASCII letter. Unicode-aware:
+    only the first code point is affected, the rest are unchanged.
+
+    Examples:
+    - first_rune_to_upper "camelCase" = "CamelCase"
+    - first_rune_to_upper "CamelCase" = "CamelCase"
+    - first_rune_to_upper "camel" = "Camel"
+    - first_rune_to_upper "こんにちは" = "こんにちは" *)

--- a/test/test_stringx.ml
+++ b/test/test_stringx.ml
@@ -592,6 +592,21 @@ let test_first_rune_to_lower () =
   Alcotest.(check string) "unicode" "こんにちは" (first_rune_to_lower "こんにちは");
   Alcotest.(check string) "empty" "" (first_rune_to_lower "")
 
+let test_first_rune_to_upper () =
+  let open Stringx in
+  Alcotest.(check string)
+    "ascii lower" "CamelCase"
+    (first_rune_to_upper "camelCase");
+  Alcotest.(check string)
+    "ascii upper" "CamelCase"
+    (first_rune_to_upper "CamelCase");
+  Alcotest.(check string) "all lower" "Camel" (first_rune_to_upper "camel");
+  Alcotest.(check string) "all upper" "CAMEL" (first_rune_to_upper "CAMEL");
+  Alcotest.(check string) "single lower" "C" (first_rune_to_upper "c");
+  Alcotest.(check string) "single upper" "C" (first_rune_to_upper "C");
+  Alcotest.(check string) "unicode" "こんにちは" (first_rune_to_upper "こんにちは");
+  Alcotest.(check string) "empty" "" (first_rune_to_upper "")
+
 let () =
   run "stringx"
     [
@@ -655,5 +670,9 @@ let () =
       ( "first rune to lower tests",
         [
           test_case "first rune to lower basic" `Quick test_first_rune_to_lower;
+        ] );
+      ( "first rune to upper tests",
+        [
+          test_case "first rune to upper basic" `Quick test_first_rune_to_upper;
         ] );
     ]

--- a/test/test_stringx.ml
+++ b/test/test_stringx.ml
@@ -578,6 +578,20 @@ let test_expand_tabs () =
     (Invalid_argument "expand_tabs: tab_size must be > 0") (fun () ->
       ignore (expand_tabs "abc\tdef" 0))
 
+let test_first_rune_to_lower () =
+  let open Stringx in
+  Alcotest.(check string)
+    "ascii upper" "camelCase"
+    (first_rune_to_lower "CamelCase");
+  Alcotest.(check string)
+    "ascii lower" "camelCase"
+    (first_rune_to_lower "camelCase");
+  Alcotest.(check string) "all upper" "cAMEL" (first_rune_to_lower "CAMEL");
+  Alcotest.(check string) "single upper" "c" (first_rune_to_lower "C");
+  Alcotest.(check string) "single lower" "c" (first_rune_to_lower "c");
+  Alcotest.(check string) "unicode" "こんにちは" (first_rune_to_lower "こんにちは");
+  Alcotest.(check string) "empty" "" (first_rune_to_lower "")
+
 let () =
   run "stringx"
     [
@@ -638,4 +652,8 @@ let () =
       ("fold sum tests", [ test_case "fold sum basic" `Quick test_fold_sum ]);
       ( "expand tabs tests",
         [ test_case "expand tabs basic" `Quick test_expand_tabs ] );
+      ( "first rune to lower tests",
+        [
+          test_case "first rune to lower basic" `Quick test_first_rune_to_lower;
+        ] );
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functions to convert only the first character of a string to lowercase or uppercase, affecting ASCII letters while leaving the rest of the string unchanged.
  * Introduced a function to expand tab characters in strings to spaces, respecting Unicode character widths.

* **Documentation**
  * Updated documentation to include usage examples and details for the new string manipulation functions.

* **Tests**
  * Added tests to verify the correct behavior of the new string case conversion functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->